### PR TITLE
Create offline-first guest list iOS app

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,45 @@
+// swift-tools-version: 5.9
+import PackageDescription
+import AppleProductTypes
+
+let package = Package(
+    name: "GuestList",
+    platforms: [
+        .iOS(.v16)
+    ],
+    products: [
+        .iOSApplication(
+            name: "GuestList",
+            targets: ["AppModule"],
+            bundleIdentifier: "com.example.GuestList",
+            teamIdentifier: "ABCDE12345",
+            displayVersion: "1.0",
+            bundleVersion: "1",
+            appIcon: .placeholder,
+            accentColor: .presetColor(.blue),
+            supportedDeviceFamilies: [
+                .phone
+            ],
+            supportedInterfaceOrientations: [
+                .portrait,
+                .portraitUpsideDown
+            ],
+            capabilities: [
+                .camera(purposeString: "Camera access is needed to scan tickets."),
+                .fileAccess(.userSelectedFiles, mode: .readOnly)
+            ]
+        )
+    ],
+    dependencies: [
+        .package(url: "https://github.com/CoreOffice/CoreXLSX.git", from: "0.17.0")
+    ],
+    targets: [
+        .executableTarget(
+            name: "AppModule",
+            dependencies: [
+                .product(name: "CoreXLSX", package: "CoreXLSX")
+            ],
+            path: "Sources"
+        )
+    ]
+)

--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
-# ticketingNative
+# GuestList iOS App
+
+This repository contains a SwiftUI-based offline-first guest management app targeting iOS 16+. The app supports importing guest data from Excel/CSV, manual guest management, QR ticket generation, offline scanning, and PDF ticket sharing.
+
+## Highlights
+
+- Local-first storage with JSON persistence managed by `GuestStore`.
+- Excel/CSV import via the Files app with duplicate detection and optional bulk QR generation.
+- Guests tab with search, sorting, filtering, manual add/edit/delete, undo deletion, and ticket actions.
+- QR ticket generation using HMAC-SHA256 signatures, PDF rendering, and Share Sheet integration.
+- Scan tab with live camera preview, torch control, tactile feedback, and offline verification.
+- Settings for event metadata, secret rotation, data export, and data reset.
+
+Open the project with Xcode 15+ (`Package.swift`) to run on iPhone simulators or devices.

--- a/Sources/AppModule/GuestListApp.swift
+++ b/Sources/AppModule/GuestListApp.swift
@@ -1,0 +1,52 @@
+import SwiftUI
+
+@main
+struct GuestListApp: App {
+    @StateObject private var guestsViewModel = GuestsViewModel()
+    @StateObject private var importViewModel = ImportViewModel()
+    @StateObject private var scanViewModel = ScanViewModel()
+
+    var body: some Scene {
+        WindowGroup {
+            RootView()
+                .environmentObject(guestsViewModel)
+                .environmentObject(importViewModel)
+                .environmentObject(scanViewModel)
+                .task {
+                    await guestsViewModel.loadInitialData()
+                    if let store = guestsViewModel.store {
+                        importViewModel.configure(with: store)
+                        await scanViewModel.configure(with: store)
+                    }
+                }
+        }
+    }
+}
+
+struct RootView: View {
+    @EnvironmentObject private var guestsViewModel: GuestsViewModel
+    @State private var selectedTab = 0
+
+    var body: some View {
+        TabView(selection: $selectedTab) {
+            GuestsView()
+                .tabItem {
+                    Label("Guests", systemImage: "person.3")
+                }
+                .tag(0)
+
+            ImportView()
+                .tabItem {
+                    Label("Import", systemImage: "square.and.arrow.down")
+                }
+                .tag(1)
+
+            ScanView()
+                .tabItem {
+                    Label("Scan", systemImage: "qrcode.viewfinder")
+                }
+                .tag(2)
+        }
+        .environmentObject(guestsViewModel)
+    }
+}

--- a/Sources/AppModule/Models/EventConfig.swift
+++ b/Sources/AppModule/Models/EventConfig.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+struct EventConfig: Identifiable, Codable {
+    var id: UUID
+    var eventName: String
+    var eventId: UUID
+    var hmacSecret: Data
+    var keyVersion: Int
+    var preferredNameColumn: String?
+
+    init(id: UUID = UUID(),
+         eventName: String = "",
+         eventId: UUID = UUID(),
+         hmacSecret: Data = HMACSecretGenerator.generate(),
+         keyVersion: Int = 1,
+         preferredNameColumn: String? = nil) {
+        self.id = id
+        self.eventName = eventName
+        self.eventId = eventId
+        self.hmacSecret = hmacSecret
+        self.keyVersion = keyVersion
+        self.preferredNameColumn = preferredNameColumn
+    }
+}
+
+enum EventConfigError: Error {
+    case failedToEncodeSecret
+}

--- a/Sources/AppModule/Models/Guest.swift
+++ b/Sources/AppModule/Models/Guest.swift
@@ -1,0 +1,55 @@
+import Foundation
+
+struct Guest: Identifiable, Codable, Hashable {
+    var id: UUID
+    var fullName: String
+    var createdAt: Date
+    var entered: Bool
+    var enteredAt: Date?
+    var ticketCode: String?
+    var qrPayload: String?
+    var qrSignature: String?
+    var qrIssuedAt: Date?
+
+    init(id: UUID = UUID(),
+         fullName: String,
+         createdAt: Date = Date(),
+         entered: Bool = false,
+         enteredAt: Date? = nil,
+         ticketCode: String? = nil,
+         qrPayload: String? = nil,
+         qrSignature: String? = nil,
+         qrIssuedAt: Date? = nil) {
+        self.id = id
+        self.fullName = fullName
+        self.createdAt = createdAt
+        self.entered = entered
+        self.enteredAt = enteredAt
+        self.ticketCode = ticketCode
+        self.qrPayload = qrPayload
+        self.qrSignature = qrSignature
+        self.qrIssuedAt = qrIssuedAt
+    }
+
+    var statusDotColor: GuestStatusColor {
+        entered ? .entered : .notEntered
+    }
+}
+
+enum GuestStatusColor {
+    case entered
+    case notEntered
+}
+
+extension Array where Element == Guest {
+    func sorted(by mode: GuestSortMode) -> [Guest] {
+        switch mode {
+        case .az:
+            return sorted { $0.fullName.localizedCaseInsensitiveCompare($1.fullName) == .orderedAscending }
+        case .za:
+            return sorted { $0.fullName.localizedCaseInsensitiveCompare($1.fullName) == .orderedDescending }
+        case .latest:
+            return sorted { $0.createdAt > $1.createdAt }
+        }
+    }
+}

--- a/Sources/AppModule/Services/GuestImportService.swift
+++ b/Sources/AppModule/Services/GuestImportService.swift
@@ -1,0 +1,101 @@
+import Foundation
+import CoreXLSX
+import UniformTypeIdentifiers
+
+struct ImportPreview: Identifiable {
+    let id = UUID()
+    let names: [String]
+    let totalCount: Int
+    let duplicateCount: Int
+}
+
+struct ImportResult {
+    let added: [Guest]
+    let skipped: [Guest]
+}
+
+enum ImportError: Error {
+    case unsupportedType
+    case unreadableFile
+    case noNameColumn
+}
+
+struct ImportConfiguration {
+    var normalizeNames: Bool = true
+    var generateQR: Bool = false
+    var selectedColumn: String?
+}
+
+final class GuestImportService {
+    private let store: GuestStore
+
+    init(store: GuestStore) {
+        self.store = store
+    }
+
+    func preview(for url: URL, column: String? = nil) async throws -> ImportPreview {
+        let names = try await readNames(from: url, column: column)
+        let normalized = names.map { NameNormalizer.normalize($0) }
+        let existing = await store.refresh()
+        let existingNormalized = Set(existing.map { NameNormalizer.normalize($0.fullName) })
+        let duplicates = normalized.filter { existingNormalized.contains($0) }
+        let uniqueNames = names.filter { !duplicates.contains(NameNormalizer.normalize($0)) }
+        let previewNames = Array(uniqueNames.prefix(10))
+        return ImportPreview(names: previewNames, totalCount: names.count, duplicateCount: duplicates.count)
+    }
+
+    func importGuests(from url: URL, configuration: ImportConfiguration) async throws -> ImportResult {
+        let names = try await readNames(from: url, column: configuration.selectedColumn)
+        let preparedGuests = names.map { name -> Guest in
+            let normalized = configuration.normalizeNames ? name.trimmingCharacters(in: .whitespacesAndNewlines) : name
+            return Guest(fullName: normalized)
+        }
+
+        let result = try await store.addOrMerge(preparedGuests)
+        return ImportResult(added: result.added, skipped: result.skipped)
+    }
+
+    private func readNames(from url: URL, column: String?) async throws -> [String] {
+        if url.pathExtension.lowercased() == "csv" {
+            return try await readCSV(url: url)
+        } else if url.pathExtension.lowercased() == "xlsx" {
+            return try await readXLSX(url: url, column: column)
+        } else {
+            throw ImportError.unsupportedType
+        }
+    }
+
+    private func readCSV(url: URL) async throws -> [String] {
+        guard let string = try? String(contentsOf: url, encoding: .utf8) else {
+            throw ImportError.unreadableFile
+        }
+        let rows = string.components(separatedBy: CharacterSet.newlines)
+        return rows.compactMap { row in
+            let trimmed = row.trimmingCharacters(in: .whitespaces)
+            return trimmed.isEmpty ? nil : trimmed
+        }
+    }
+
+    private func readXLSX(url: URL, column: String?) async throws -> [String] {
+        guard let file = XLSXFile(filepath: url.path) else {
+            throw ImportError.unreadableFile
+        }
+        var names: [String] = []
+        for wbk in try file.parseWorkbooks() {
+            for (name, path) in try file.parseWorksheetPathsAndNames(workbook: wbk) {
+                let worksheet = try file.parseWorksheet(at: path)
+                let sharedStrings = try file.parseSharedStrings()
+                let columnName = column ?? "A"
+                for row in worksheet.data?.rows ?? [] {
+                    if let cell = row.cells.first(where: { $0.reference.column == ColumnReference(columnName) }) {
+                        if let value = cell.stringValue(sharedStrings) {
+                            names.append(value)
+                        }
+                    }
+                }
+                if !names.isEmpty { return names }
+            }
+        }
+        return names
+    }
+}

--- a/Sources/AppModule/Services/GuestStore.swift
+++ b/Sources/AppModule/Services/GuestStore.swift
@@ -1,0 +1,157 @@
+import Foundation
+
+actor GuestStore {
+    private let guestsURL: URL
+    private let configURL: URL
+    private let decoder = JSONDecoder()
+    private let encoder = JSONEncoder()
+
+    private(set) var guests: [Guest] = []
+    private(set) var eventConfig: EventConfig
+    private var undoStack: [Guest]
+
+    init() async {
+        let directory = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first ?? FileManager.default.temporaryDirectory
+        guestsURL = directory.appendingPathComponent("guests.json")
+        configURL = directory.appendingPathComponent("eventConfig.json")
+        encoder.outputFormatting = [.prettyPrinted]
+
+        if let data = try? Data(contentsOf: configURL), let config = try? decoder.decode(EventConfig.self, from: data) {
+            eventConfig = config
+        } else {
+            eventConfig = EventConfig()
+            try? persistConfig()
+        }
+
+        if let data = try? Data(contentsOf: guestsURL), let guests = try? decoder.decode([Guest].self, from: data) {
+            self.guests = guests
+        }
+
+        undoStack = []
+    }
+
+    func refresh() -> [Guest] {
+        guests
+    }
+
+    func save(guest: Guest) async throws {
+        if let index = guests.firstIndex(where: { $0.id == guest.id }) {
+            guests[index] = guest
+        } else {
+            guests.append(guest)
+        }
+        try persistGuests()
+        notifyChange()
+    }
+
+    func addGuest(fullName: String) async throws -> Guest {
+        let normalized = NameNormalizer.normalize(fullName)
+        if guests.contains(where: { NameNormalizer.normalize($0.fullName) == normalized }) {
+            throw GuestStoreError.duplicate
+        }
+        let guest = Guest(fullName: fullName)
+        guests.append(guest)
+        try persistGuests()
+        notifyChange()
+        return guest
+    }
+
+    func deleteGuest(id: UUID) async throws -> Guest? {
+        guard let index = guests.firstIndex(where: { $0.id == id }) else { return nil }
+        let removed = guests.remove(at: index)
+        undoStack.append(removed)
+        try persistGuests()
+        notifyChange()
+        return removed
+    }
+
+    func undoDelete() async throws {
+        guard let guest = undoStack.popLast() else { return }
+        guests.append(guest)
+        try persistGuests()
+        notifyChange()
+    }
+
+    func toggleEntered(id: UUID, entered: Bool) async throws {
+        guard let index = guests.firstIndex(where: { $0.id == id }) else { return }
+        guests[index].entered = entered
+        guests[index].enteredAt = entered ? Date() : nil
+        try persistGuests()
+        notifyChange()
+    }
+
+    func updateEventConfig(_ update: (inout EventConfig) -> Void) async throws {
+        update(&eventConfig)
+        try persistConfig()
+        notifyChange()
+    }
+
+    func replaceAll(with newGuests: [Guest]) async throws {
+        guests = newGuests
+        try persistGuests()
+        notifyChange()
+    }
+
+    func addOrMerge(_ newGuests: [Guest]) async throws -> (added: [Guest], skipped: [Guest]) {
+        var added: [Guest] = []
+        var skipped: [Guest] = []
+
+        for guest in newGuests {
+            let normalized = NameNormalizer.normalize(guest.fullName)
+            if guests.contains(where: { NameNormalizer.normalize($0.fullName) == normalized }) {
+                skipped.append(guest)
+            } else {
+                guests.append(guest)
+                added.append(guest)
+            }
+        }
+
+        if !added.isEmpty {
+            try persistGuests()
+            notifyChange()
+        }
+
+        return (added, skipped)
+    }
+
+    func updateTicket(for guestId: UUID, ticketCode: String, payload: String, signature: String, issuedAt: Date) async throws {
+        guard let index = guests.firstIndex(where: { $0.id == guestId }) else { return }
+        guests[index].ticketCode = ticketCode
+        guests[index].qrPayload = payload
+        guests[index].qrSignature = signature
+        guests[index].qrIssuedAt = issuedAt
+        try persistGuests()
+    }
+
+    func guest(forTicketCode code: String) -> Guest? {
+        guests.first { $0.ticketCode == code }
+    }
+
+    func guest(by id: UUID) -> Guest? {
+        guests.first { $0.id == id }
+    }
+
+    func persistGuests() throws {
+        let data = try encoder.encode(guests)
+        try data.write(to: guestsURL, options: .atomic)
+    }
+
+    func persistConfig() throws {
+        let data = try encoder.encode(eventConfig)
+        try data.write(to: configURL, options: .atomic)
+    }
+
+    private func notifyChange() {
+        Task { @MainActor in
+            NotificationCenter.default.post(name: .guestStoreDidUpdate, object: nil)
+        }
+    }
+}
+
+enum GuestStoreError: Error {
+    case duplicate
+}
+
+extension Notification.Name {
+    static let guestStoreDidUpdate = Notification.Name("GuestStoreDidUpdate")
+}

--- a/Sources/AppModule/Services/NameNormalizer.swift
+++ b/Sources/AppModule/Services/NameNormalizer.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+enum NameNormalizer {
+    static func normalize(_ name: String) -> String {
+        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        let collapsedSpaces = trimmed.replacingOccurrences(of: "\\s+", with: " ", options: .regularExpression)
+        let folding = collapsedSpaces.folding(options: [.diacriticInsensitive, .caseInsensitive], locale: .current)
+        return folding.uppercased()
+    }
+}

--- a/Sources/AppModule/Services/PDFTicketRenderer.swift
+++ b/Sources/AppModule/Services/PDFTicketRenderer.swift
@@ -1,0 +1,44 @@
+import Foundation
+import UIKit
+
+final class PDFTicketRenderer {
+    func renderTicket(eventName: String, guest: Guest, ticket: QRTicket, image: UIImage) throws -> URL {
+        let format = UIGraphicsPDFRendererFormat()
+        let pageRect = CGRect(x: 0, y: 0, width: 612, height: 792)
+        let renderer = UIGraphicsPDFRenderer(bounds: pageRect, format: format)
+        let data = renderer.pdfData { context in
+            context.beginPage()
+            let titleAttributes: [NSAttributedString.Key: Any] = [
+                .font: UIFont.preferredFont(forTextStyle: .largeTitle)
+            ]
+            let nameAttributes: [NSAttributedString.Key: Any] = [
+                .font: UIFont.preferredFont(forTextStyle: .title1)
+            ]
+            let codeAttributes: [NSAttributedString.Key: Any] = [
+                .font: UIFont.preferredFont(forTextStyle: .subheadline),
+                .foregroundColor: UIColor.secondaryLabel
+            ]
+
+            let inset: CGFloat = 48
+            eventName.draw(at: CGPoint(x: inset, y: inset), withAttributes: titleAttributes)
+            guest.fullName.draw(at: CGPoint(x: inset, y: inset + 60), withAttributes: nameAttributes)
+            "Ticket #\(ticket.code)".draw(at: CGPoint(x: inset, y: inset + 110), withAttributes: codeAttributes)
+
+            let qrSize: CGFloat = 240
+            let qrRect = CGRect(x: (pageRect.width - qrSize) / 2, y: inset + 160, width: qrSize, height: qrSize)
+            image.draw(in: qrRect)
+
+            let note = "Show this QR at the entrance"
+            let noteAttributes: [NSAttributedString.Key: Any] = [
+                .font: UIFont.preferredFont(forTextStyle: .footnote),
+                .foregroundColor: UIColor.secondaryLabel
+            ]
+            let noteSize = note.size(withAttributes: noteAttributes)
+            note.draw(at: CGPoint(x: (pageRect.width - noteSize.width) / 2, y: qrRect.maxY + 24), withAttributes: noteAttributes)
+        }
+
+        let fileURL = FileManager.default.temporaryDirectory.appendingPathComponent("Ticket-\(ticket.code).pdf")
+        try data.write(to: fileURL)
+        return fileURL
+    }
+}

--- a/Sources/AppModule/Services/QRCodeService.swift
+++ b/Sources/AppModule/Services/QRCodeService.swift
@@ -1,0 +1,129 @@
+import Foundation
+import CryptoKit
+import CoreImage.CIFilterBuiltins
+import SwiftUI
+
+struct QRTicket {
+    let payload: String
+    let signature: String
+    let code: String
+    let issuedAt: Date
+    var qrString: String {
+        "\(payload).\(signature)"
+    }
+}
+
+enum QRServiceError: Error {
+    case encodingFailure
+    case signatureMismatch
+    case guestNotFound
+}
+
+final class QRCodeService {
+    private let context = CIContext()
+    private let filter = CIFilter.qrCodeGenerator()
+    private let store: GuestStore
+
+    init(store: GuestStore) {
+        self.store = store
+    }
+
+    func generateTicket(for guest: Guest) async throws -> QRTicket {
+        let config = await store.eventConfig
+        let issuedAt = Date()
+        let header = TicketHeader(algorithm: "HS256", keyVersion: config.keyVersion)
+        let ticketCode = TicketCodeGenerator.generate()
+        let payload = TicketPayload(gid: guest.id, e: config.eventId, iat: issuedAt, n: guest.fullName, tc: ticketCode)
+        let encodedHeader = try encodeJSON(header)
+        let encodedPayload = try encodeJSON(payload)
+        let signingInput = "\(encodedHeader).\(encodedPayload)"
+        let signature = sign(input: signingInput, secret: config.hmacSecret)
+        let combinedPayload = signingInput
+        let ticket = QRTicket(payload: combinedPayload, signature: signature, code: ticketCode, issuedAt: issuedAt)
+        try await store.updateTicket(for: guest.id, ticketCode: ticketCode, payload: combinedPayload, signature: signature, issuedAt: issuedAt)
+        return ticket
+    }
+
+    func verify(_ qrString: String) async throws -> Guest {
+        let components = qrString.components(separatedBy: ".")
+        guard components.count >= 3 else { throw QRServiceError.signatureMismatch }
+        let header = components[0]
+        let payload = components[1]
+        let signature = components[2]
+        let signingInput = "\(header).\(payload)"
+        let headerData = try decodeBase64(header)
+        let payloadData = try decodeBase64(payload)
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .secondsSince1970
+        let headerModel = try decoder.decode(TicketHeader.self, from: headerData)
+        var config = await store.eventConfig
+        guard headerModel.algorithm == "HS256" else { throw QRServiceError.signatureMismatch }
+        let secret = config.hmacSecret
+        let expectedSignature = sign(input: signingInput, secret: secret)
+        guard expectedSignature == signature else { throw QRServiceError.signatureMismatch }
+        let payloadModel = try decoder.decode(TicketPayload.self, from: payloadData)
+        guard let guest = await store.guest(by: payloadModel.gid) else { throw QRServiceError.guestNotFound }
+        return guest
+    }
+
+    func makeImage(from string: String) -> UIImage? {
+        filter.setValue(Data(string.utf8), forKey: "inputMessage")
+        guard let outputImage = filter.outputImage else { return nil }
+        let scaled = outputImage.transformed(by: CGAffineTransform(scaleX: 12, y: 12))
+        guard let cgImage = context.createCGImage(scaled, from: scaled.extent) else { return nil }
+        return UIImage(cgImage: cgImage)
+    }
+
+    private func sign(input: String, secret: Data) -> String {
+        let key = SymmetricKey(data: secret)
+        let signature = HMAC<SHA256>.authenticationCode(for: Data(input.utf8), using: key)
+        return Data(signature).base64URLEncodedString()
+    }
+
+    private func encodeJSON<T: Encodable>(_ value: T) throws -> String {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .secondsSince1970
+        let data = try encoder.encode(value)
+        return data.base64URLEncodedString()
+    }
+
+    private func decodeBase64(_ string: String) throws -> Data {
+        guard let data = Data(base64URLEncoded: string) else { throw QRServiceError.signatureMismatch }
+        return data
+    }
+}
+
+struct TicketHeader: Codable {
+    let algorithm: String
+    let keyVersion: Int
+
+    enum CodingKeys: String, CodingKey {
+        case algorithm = "alg"
+        case keyVersion = "k"
+    }
+}
+
+struct TicketPayload: Codable {
+    let gid: UUID
+    let e: UUID
+    let iat: Date
+    let exp: Date?
+    let n: String
+    let tc: String
+
+    init(gid: UUID, e: UUID, iat: Date, exp: Date? = nil, n: String, tc: String) {
+        self.gid = gid
+        self.e = e
+        self.iat = iat
+        self.exp = exp
+        self.n = n
+        self.tc = tc
+    }
+}
+
+enum TicketCodeGenerator {
+    static func generate() -> String {
+        let letters = Array("ABCDEFGHJKLMNPQRSTUVWXYZ23456789")
+        return String((0..<6).map { _ in letters.randomElement()! })
+    }
+}

--- a/Sources/AppModule/Utilities/Base64URL.swift
+++ b/Sources/AppModule/Utilities/Base64URL.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+extension Data {
+    func base64URLEncodedString() -> String {
+        return base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+    }
+
+    init?(base64URLEncoded string: String) {
+        var base64 = string
+            .replacingOccurrences(of: "-", with: "+")
+            .replacingOccurrences(of: "_", with: "/")
+        let padding = 4 - base64.count % 4
+        if padding < 4 {
+            base64.append(String(repeating: "=", count: padding))
+        }
+        self.init(base64Encoded: base64)
+    }
+}

--- a/Sources/AppModule/Utilities/Color+Hex.swift
+++ b/Sources/AppModule/Utilities/Color+Hex.swift
@@ -1,0 +1,17 @@
+import SwiftUI
+
+extension Color {
+    init(hex: String) {
+        var string = hex.trimmingCharacters(in: CharacterSet.alphanumerics.inverted)
+        if string.count == 6 {
+            string = "FF" + string
+        }
+        var value: UInt64 = 0
+        Scanner(string: string).scanHexInt64(&value)
+        let a = Double((value & 0xFF000000) >> 24) / 255.0
+        let r = Double((value & 0x00FF0000) >> 16) / 255.0
+        let g = Double((value & 0x0000FF00) >> 8) / 255.0
+        let b = Double(value & 0x000000FF) / 255.0
+        self.init(.sRGB, red: r, green: g, blue: b, opacity: a)
+    }
+}

--- a/Sources/AppModule/Utilities/HMACSecretGenerator.swift
+++ b/Sources/AppModule/Utilities/HMACSecretGenerator.swift
@@ -1,0 +1,9 @@
+import Foundation
+import CryptoKit
+
+enum HMACSecretGenerator {
+    static func generate() -> Data {
+        let keyData = SymmetricKey(size: .bits256)
+        return keyData.withUnsafeBytes { Data($0) }
+    }
+}

--- a/Sources/AppModule/ViewModels/GuestsViewModel.swift
+++ b/Sources/AppModule/ViewModels/GuestsViewModel.swift
@@ -1,0 +1,160 @@
+import Foundation
+import Combine
+
+@MainActor
+final class GuestsViewModel: ObservableObject {
+    @Published private(set) var guests: [Guest] = []
+    @Published var sortMode: GuestSortMode = .az {
+        didSet { applyFilters() }
+    }
+    @Published var filter: GuestFilter = .all {
+        didSet { applyFilters() }
+    }
+    @Published var searchText: String = "" {
+        didSet { applyFilters() }
+    }
+    @Published private(set) var filteredGuests: [Guest] = []
+    @Published private(set) var totalCount: Int = 0
+    @Published private(set) var enteredCount: Int = 0
+    @Published private(set) var undoAvailable: Bool = false
+    @Published private(set) var eventName: String = ""
+
+    private(set) var store: GuestStore?
+    private var cancellables = Set<AnyCancellable>()
+    private var storeCancellable: AnyCancellable?
+
+    func loadInitialData() async {
+        store = await GuestStore()
+        guests = await store?.refresh() ?? []
+        await updateEventName()
+        applyFilters()
+        observeStoreChanges()
+    }
+
+    func refresh() async {
+        guests = await store?.refresh() ?? []
+        await updateEventName()
+        applyFilters()
+    }
+
+    func addGuest(fullName: String) async throws {
+        guard let store else { return }
+        do {
+            let guest = try await store.addGuest(fullName: fullName)
+            guests.append(guest)
+            applyFilters()
+        } catch GuestStoreError.duplicate {
+            throw GuestViewModelError.duplicate
+        }
+    }
+
+    func updateGuest(_ guest: Guest, name: String) async throws {
+        guard let store else { return }
+        let normalized = NameNormalizer.normalize(name)
+        if guests.contains(where: { $0.id != guest.id && NameNormalizer.normalize($0.fullName) == normalized }) {
+            throw GuestViewModelError.duplicate
+        }
+        var updatedGuest = guest
+        updatedGuest.fullName = name
+        try await store.save(guest: updatedGuest)
+        if let index = guests.firstIndex(where: { $0.id == guest.id }) {
+            guests[index] = updatedGuest
+        }
+        applyFilters()
+    }
+
+    func deleteGuest(_ guest: Guest) async {
+        guard let store else { return }
+        _ = try? await store.deleteGuest(id: guest.id)
+        guests.removeAll { $0.id == guest.id }
+        undoAvailable = true
+        applyFilters()
+        Task { @MainActor in
+            try? await Task.sleep(nanoseconds: 5_000_000_000)
+            if undoAvailable {
+                undoAvailable = false
+            }
+        }
+    }
+
+    func undoDelete() async {
+        guard let store else { return }
+        try? await store.undoDelete()
+        guests = await store.refresh()
+        undoAvailable = false
+        applyFilters()
+    }
+
+    func toggleEntered(_ guest: Guest, entered: Bool) async {
+        guard let store else { return }
+        try? await store.toggleEntered(id: guest.id, entered: entered)
+        if let index = guests.firstIndex(where: { $0.id == guest.id }) {
+            guests[index].entered = entered
+            guests[index].enteredAt = entered ? Date() : nil
+        }
+        applyFilters()
+    }
+
+    func handleImportResult(_ result: ImportResult) async {
+        guests = await store?.refresh() ?? []
+        applyFilters()
+    }
+
+    func stats(for guests: [Guest]) {
+        totalCount = guests.count
+        enteredCount = guests.filter { $0.entered }.count
+    }
+
+    private func applyFilters() {
+        var working = guests
+
+        switch filter {
+        case .all:
+            break
+        case .entered:
+            working = working.filter { $0.entered }
+        case .notEntered:
+            working = working.filter { !$0.entered }
+        }
+
+        if !searchText.isEmpty {
+            working = working.filter { $0.fullName.localizedCaseInsensitiveContains(searchText) }
+        }
+
+        working = working.sorted(by: sortMode)
+        filteredGuests = working
+        stats(for: guests)
+    }
+
+    private func observeStoreChanges() {
+        storeCancellable = NotificationCenter.default.publisher(for: .guestStoreDidUpdate)
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                Task { await self?.refresh() }
+            }
+    }
+
+    private func updateEventName() async {
+        guard let store else { return }
+        let config = await store.eventConfig
+        await MainActor.run {
+            eventName = config.eventName
+        }
+    }
+}
+
+enum GuestSortMode: String, CaseIterable {
+    case az = "A–Z"
+    case za = "Z–A"
+    case latest = "Latest"
+}
+
+enum GuestFilter: String, CaseIterable {
+    case all = "All"
+    case entered = "Entered"
+    case notEntered = "Not Entered"
+}
+
+enum GuestViewModelError: Error {
+    case duplicate
+}

--- a/Sources/AppModule/ViewModels/ImportViewModel.swift
+++ b/Sources/AppModule/ViewModels/ImportViewModel.swift
@@ -1,0 +1,49 @@
+import Foundation
+import SwiftUI
+
+@MainActor
+final class ImportViewModel: ObservableObject {
+    @Published var selectedURL: URL?
+    @Published var preview: ImportPreview?
+    @Published var configuration = ImportConfiguration()
+    @Published var isImporting = false
+    @Published var importSummary: ImportResult?
+    @Published var errorMessage: String?
+
+    private var service: GuestImportService?
+    private var qrService: QRCodeService?
+
+    func configure(with store: GuestStore) {
+        service = GuestImportService(store: store)
+        qrService = QRCodeService(store: store)
+    }
+
+    func handleFileSelection(url: URL) async {
+        selectedURL = url
+        guard let service = service else { return }
+        do {
+            preview = try await service.preview(for: url, column: configuration.selectedColumn)
+            errorMessage = nil
+            importSummary = nil
+        } catch {
+            errorMessage = "Couldn't read this file. Try another sheet/column or export as CSV."
+        }
+    }
+
+    func runImport() async {
+        guard let url = selectedURL, let service = service else { return }
+        isImporting = true
+        defer { isImporting = false }
+        do {
+            let result = try await service.importGuests(from: url, configuration: configuration)
+            importSummary = result
+            if configuration.generateQR, let qrService {
+                for guest in result.added {
+                    _ = try? await qrService.generateTicket(for: guest)
+                }
+            }
+        } catch {
+            errorMessage = "Import failed."
+        }
+    }
+}

--- a/Sources/AppModule/ViewModels/ScanViewModel.swift
+++ b/Sources/AppModule/ViewModels/ScanViewModel.swift
@@ -1,0 +1,109 @@
+import Foundation
+import AVFoundation
+import SwiftUI
+import UIKit
+
+@MainActor
+final class ScanViewModel: NSObject, ObservableObject, AVCaptureMetadataOutputObjectsDelegate {
+    enum ScanState: Equatable {
+        case idle
+        case success(String, Date, String)
+        case duplicate(String, Date)
+        case invalid
+    }
+
+    @Published private(set) var state: ScanState = .idle
+    @Published private(set) var recentScans: [ScanRecord] = []
+    @Published var torchEnabled = false
+
+    private var captureSession: AVCaptureSession?
+    private var previewLayer: AVCaptureVideoPreviewLayer?
+    private var qrService: QRCodeService?
+    private var store: GuestStore?
+
+    func configure(with store: GuestStore) async {
+        self.store = store
+        self.qrService = QRCodeService(store: store)
+        setupSession()
+    }
+
+    func makePreviewLayer() -> AVCaptureVideoPreviewLayer? {
+        previewLayer
+    }
+
+    func toggleTorch() {
+        guard let device = AVCaptureDevice.default(for: .video), device.hasTorch else { return }
+        do {
+            try device.lockForConfiguration()
+            device.torchMode = torchEnabled ? .off : .on
+            device.unlockForConfiguration()
+            torchEnabled.toggle()
+        } catch {
+            print("Torch error: \(error)")
+        }
+    }
+
+    private func setupSession() {
+        let session = AVCaptureSession()
+        guard let device = AVCaptureDevice.default(for: .video),
+              let input = try? AVCaptureDeviceInput(device: device) else {
+            return
+        }
+        session.addInput(input)
+        let output = AVCaptureMetadataOutput()
+        session.addOutput(output)
+        output.setMetadataObjectsDelegate(self, queue: DispatchQueue.main)
+        output.metadataObjectTypes = [.qr]
+        previewLayer = AVCaptureVideoPreviewLayer(session: session)
+        previewLayer?.videoGravity = .resizeAspectFill
+        captureSession = session
+        session.startRunning()
+    }
+
+    func metadataOutput(_ output: AVCaptureMetadataOutput, didOutput metadataObjects: [AVMetadataObject], from connection: AVCaptureConnection) {
+        guard let metadataObject = metadataObjects.first as? AVMetadataMachineReadableCodeObject,
+              metadataObject.type == .qr,
+              let string = metadataObject.stringValue,
+              let service = qrService,
+              let store = store else { return }
+
+        Task {
+            do {
+                let guest = try await service.verify(string)
+                if guest.entered {
+                    state = .duplicate(guest.fullName, guest.enteredAt ?? Date())
+                    addRecord(status: .duplicate, name: guest.fullName)
+                    UIImpactFeedbackGenerator(style: .medium).impactOccurred()
+                } else {
+                    try await store.toggleEntered(id: guest.id, entered: true)
+                    state = .success(guest.fullName, Date(), guest.ticketCode ?? "")
+                    addRecord(status: .success, name: guest.fullName)
+                    UINotificationFeedbackGenerator().notificationOccurred(.success)
+                }
+            } catch {
+                state = .invalid
+                addRecord(status: .invalid, name: nil)
+                UINotificationFeedbackGenerator().notificationOccurred(.error)
+            }
+        }
+    }
+
+    private func addRecord(status: ScanRecord.Status, name: String?) {
+        let record = ScanRecord(status: status, name: name, timestamp: Date())
+        recentScans.insert(record, at: 0)
+        recentScans = Array(recentScans.prefix(20))
+    }
+}
+
+struct ScanRecord: Identifiable {
+    enum Status {
+        case success
+        case duplicate
+        case invalid
+    }
+
+    let id = UUID()
+    let status: Status
+    let name: String?
+    let timestamp: Date
+}

--- a/Sources/AppModule/Views/AddEditGuestView.swift
+++ b/Sources/AppModule/Views/AddEditGuestView.swift
@@ -1,0 +1,55 @@
+import SwiftUI
+
+struct AddEditGuestView: View {
+    enum Mode {
+        case add
+        case edit(Guest)
+
+        var title: String {
+            switch self {
+            case .add: return "Add Guest"
+            case .edit: return "Edit Guest"
+            }
+        }
+    }
+
+    var mode: Mode
+    var onSave: (String) -> Void
+    @Environment(\.dismiss) private var dismiss
+    @State private var name: String = ""
+    @State private var showDuplicateAlert = false
+
+    init(mode: Mode, onSave: @escaping (String) -> Void) {
+        self.mode = mode
+        self.onSave = onSave
+        if case let .edit(guest) = mode {
+            _name = State(initialValue: guest.fullName)
+        }
+    }
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section(header: Text("Full Name")) {
+                    TextField("Full Name", text: $name)
+                        .textInputAutocapitalization(.words)
+                }
+            }
+            .navigationTitle(mode.title)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Save") {
+                        let normalized = name.trimmingCharacters(in: .whitespacesAndNewlines)
+                        guard !normalized.isEmpty else { return }
+                        onSave(normalized)
+                        dismiss()
+                    }
+                    .disabled(name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                }
+            }
+        }
+    }
+}

--- a/Sources/AppModule/Views/GuestRowView.swift
+++ b/Sources/AppModule/Views/GuestRowView.swift
@@ -1,0 +1,64 @@
+import SwiftUI
+
+struct GuestRowView: View {
+    enum Action {
+        case toggleEntered(Bool)
+        case edit
+        case delete
+        case createQR
+    }
+
+    let guest: Guest
+    var onAction: (Action) -> Void
+
+    var body: some View {
+        HStack {
+            VStack(alignment: .leading, spacing: 4) {
+                HStack(spacing: 8) {
+                    Circle()
+                        .fill(guest.entered ? Color(hex: "2E7D32") : Color.secondary)
+                        .frame(width: 10, height: 10)
+                    Text(guest.fullName)
+                        .font(.body)
+                        .bold()
+                }
+                if let code = guest.ticketCode {
+                    Text("Ticket: \(code)")
+                        .font(.footnote)
+                        .foregroundColor(.secondary)
+                }
+            }
+            Spacer()
+            Toggle(isOn: .init(get: { guest.entered }, set: { onAction(.toggleEntered($0)) })) {
+                Text("Entered")
+                    .font(.footnote)
+            }
+            .toggleStyle(.switch)
+            .labelsHidden()
+        }
+        .padding(.vertical, 8)
+        .contextMenu {
+            Button("Edit", systemImage: "square.and.pencil") {
+                onAction(.edit)
+            }
+            Button("Delete", systemImage: "trash", role: .destructive) {
+                onAction(.delete)
+            }
+            Button(guest.ticketCode == nil ? "Create QR" : "Reissue QR", systemImage: "qrcode") {
+                onAction(.createQR)
+            }
+        }
+        .swipeActions(edge: .trailing) {
+            Button(role: .destructive) {
+                onAction(.delete)
+            } label: {
+                Label("Delete", systemImage: "trash")
+            }
+            Button {
+                onAction(.edit)
+            } label: {
+                Label("Edit", systemImage: "square.and.pencil")
+            }
+        }
+    }
+}

--- a/Sources/AppModule/Views/GuestsView.swift
+++ b/Sources/AppModule/Views/GuestsView.swift
@@ -1,0 +1,220 @@
+import SwiftUI
+import UIKit
+
+struct GuestsView: View {
+    @EnvironmentObject private var viewModel: GuestsViewModel
+    @State private var showingAddSheet = false
+    @State private var selectedGuest: Guest?
+    @State private var showSettings = false
+    @State private var ticketPreview: TicketPreviewData?
+
+    var body: some View {
+        NavigationStack {
+            VStack(spacing: 16) {
+                summaryChips
+                controlRow
+                guestList
+            }
+            .padding(.horizontal, 16)
+            .padding(.top, 16)
+            .navigationTitle("Guests")
+            .toolbar {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button(action: { showSettings = true }) {
+                        Image(systemName: "gearshape")
+                    }
+                }
+            }
+            .sheet(isPresented: $showingAddSheet) {
+                AddEditGuestView(mode: selectedGuest == nil ? .add : .edit(selectedGuest!)) { name in
+                    Task {
+                        if let guest = selectedGuest {
+                            try? await viewModel.updateGuest(guest, name: name)
+                        } else {
+                            try? await viewModel.addGuest(fullName: name)
+                        }
+                        selectedGuest = nil
+                    }
+                }
+            }
+            .sheet(isPresented: $showSettings) {
+                SettingsView()
+            }
+            .sheet(item: $ticketPreview) { data in
+                TicketPreviewView(guest: data.guest, ticket: data.ticket, image: data.image) { url in
+                    saveTicket(url: url)
+                }
+            }
+            .overlay(alignment: .bottomTrailing) {
+                Button(action: {
+                    selectedGuest = nil
+                    showingAddSheet = true
+                }) {
+                    Label("Add Guest", systemImage: "plus")
+                        .font(.headline)
+                        .padding()
+                        .background(Color(hex: "1E88E5"))
+                        .foregroundColor(.white)
+                        .clipShape(Capsule())
+                        .shadow(radius: 4)
+                }
+                .padding(24)
+            }
+            .overlay(alignment: .bottom) {
+                if viewModel.undoAvailable {
+                    HStack {
+                        Text("Guest deleted")
+                            .foregroundColor(.white)
+                        Spacer()
+                        Button("Undo") {
+                            Task { await viewModel.undoDelete() }
+                        }
+                        .foregroundColor(.white)
+                        .bold()
+                    }
+                    .padding()
+                    .background(Color.black.opacity(0.8))
+                    .cornerRadius(16)
+                    .padding(.horizontal, 32)
+                    .padding(.bottom, 40)
+                    .transition(.move(edge: .bottom).combined(with: .opacity))
+                }
+            }
+        }
+    }
+
+    private var summaryChips: some View {
+        HStack(spacing: 12) {
+            SummaryChip(title: "Total", value: viewModel.totalCount)
+            SummaryChip(title: "Entered", value: viewModel.enteredCount, color: Color(hex: "2E7D32"))
+            SummaryChip(title: "Not Entered", value: viewModel.totalCount - viewModel.enteredCount)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private var controlRow: some View {
+        VStack(spacing: 8) {
+            TextField("Search guests…", text: $viewModel.searchText)
+                .textFieldStyle(.roundedBorder)
+                .textInputAutocapitalization(.words)
+                .disableAutocorrection(true)
+            Picker("Sort", selection: $viewModel.sortMode) {
+                ForEach(GuestSortMode.allCases, id: \.self) { mode in
+                    Text(mode.rawValue).tag(mode)
+                }
+            }
+            .pickerStyle(.segmented)
+
+            Picker("Filter", selection: $viewModel.filter) {
+                ForEach(GuestFilter.allCases, id: \.self) { filter in
+                    Text(filter.rawValue).tag(filter)
+                }
+            }
+            .pickerStyle(.segmented)
+        }
+    }
+
+    private var guestList: some View {
+        Group {
+            if viewModel.filteredGuests.isEmpty {
+                VStack(spacing: 16) {
+                    Image(systemName: "person.crop.circle.badge.questionmark")
+                        .font(.system(size: 64))
+                        .foregroundColor(.secondary)
+                    Text("No guests yet")
+                        .font(.title2)
+                        .bold()
+                    Text("Import from Excel or add manually")
+                        .foregroundColor(.secondary)
+                    Button("Import Guests") {}
+                        .buttonStyle(.borderedProminent)
+                    Button("Add Guest") {
+                        selectedGuest = nil
+                        showingAddSheet = true
+                    }
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .padding(.top, 40)
+            } else {
+                List {
+                    ForEach(viewModel.filteredGuests) { guest in
+                        GuestRowView(guest: guest) { action in
+                            handleAction(action, for: guest)
+                        }
+                        .listRowBackground(Color.clear)
+                    }
+                }
+                .listStyle(.plain)
+            }
+        }
+    }
+
+    private func handleAction(_ action: GuestRowView.Action, for guest: Guest) {
+        switch action {
+        case .toggleEntered(let entered):
+            Task { await viewModel.toggleEntered(guest, entered: entered) }
+        case .edit:
+            selectedGuest = guest
+            showingAddSheet = true
+        case .delete:
+            Task { await viewModel.deleteGuest(guest) }
+        case .createQR:
+            Task {
+                await generateTicket(for: guest)
+            }
+        }
+    }
+
+    private func generateTicket(for guest: Guest) async {
+        guard let store = viewModel.store else { return }
+        let qrService = QRCodeService(store: store)
+        if let ticket = try? await qrService.generateTicket(for: guest),
+           let image = qrService.makeImage(from: ticket.qrString) {
+            await MainActor.run {
+                ticketPreview = TicketPreviewData(guest: guest, ticket: ticket, image: image)
+            }
+        }
+    }
+
+    private func saveTicket(url: URL) {
+        Task { @MainActor in
+            let controller = UIActivityViewController(activityItems: [url], applicationActivities: nil)
+            guard let scene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+                  let root = scene.windows.first?.rootViewController else { return }
+            root.present(controller, animated: true)
+        }
+    }
+}
+
+struct SummaryChip: View {
+    let title: String
+    let value: Int
+    var color: Color = .accentColor
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(title)
+                .font(.footnote)
+                .foregroundColor(.secondary)
+            Text("\(value)")
+                .font(.headline)
+        }
+        .padding(12)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: 12)
+                .fill(Color(.secondarySystemBackground))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 12)
+                        .stroke(color.opacity(0.4), lineWidth: 1)
+                )
+        )
+    }
+}
+
+struct TicketPreviewData: Identifiable {
+    let id = UUID()
+    let guest: Guest
+    let ticket: QRTicket
+    let image: UIImage
+}

--- a/Sources/AppModule/Views/ImportView.swift
+++ b/Sources/AppModule/Views/ImportView.swift
@@ -1,0 +1,127 @@
+import SwiftUI
+import UniformTypeIdentifiers
+import UIKit
+
+struct ImportView: View {
+    @EnvironmentObject private var viewModel: ImportViewModel
+    @EnvironmentObject private var guestsViewModel: GuestsViewModel
+    @State private var showingDocumentPicker = false
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 24) {
+                    Text("Import")
+                        .font(.largeTitle)
+                        .bold()
+                        .frame(maxWidth: .infinity, alignment: .leading)
+
+                    Button(action: { showingDocumentPicker = true }) {
+                        Label("Select File", systemImage: "square.and.arrow.down")
+                            .font(.headline)
+                            .frame(maxWidth: .infinity)
+                            .padding()
+                            .background(Color(hex: "1E88E5"))
+                            .foregroundColor(.white)
+                            .cornerRadius(16)
+                    }
+
+                    Toggle("Normalize names", isOn: $viewModel.configuration.normalizeNames)
+                    Toggle("Generate QR for new guests", isOn: $viewModel.configuration.generateQR)
+
+                    if let preview = viewModel.preview {
+                        VStack(alignment: .leading, spacing: 12) {
+                            Text("Preview")
+                                .font(.headline)
+                            Text("Total rows: \(preview.totalCount)")
+                            Text("Duplicates skipped: \(preview.duplicateCount)")
+                            Divider()
+                            ForEach(preview.names, id: \.self) { name in
+                                Text(name)
+                                    .frame(maxWidth: .infinity, alignment: .leading)
+                            }
+                        }
+                        .padding()
+                        .background(RoundedRectangle(cornerRadius: 16).fill(Color(.secondarySystemBackground)))
+                    }
+
+                    if let summary = viewModel.importSummary {
+                        VStack(alignment: .leading, spacing: 8) {
+                            Text("Import Summary")
+                                .font(.headline)
+                            Text("Added: \(summary.added.count)")
+                            Text("Skipped duplicates: \(summary.skipped.count)")
+                        }
+                        .padding()
+                        .background(RoundedRectangle(cornerRadius: 16).fill(Color(.secondarySystemBackground)))
+                    }
+
+                    if let error = viewModel.errorMessage {
+                        Text(error)
+                            .foregroundColor(Color(hex: "C62828"))
+                    }
+
+                    Button("Import Guests") {
+                        Task {
+                            await viewModel.runImport()
+                            await guestsViewModel.refresh()
+                        }
+                    }
+                    .disabled(viewModel.selectedURL == nil)
+                    .buttonStyle(.borderedProminent)
+                }
+                .padding(16)
+            }
+            .sheet(isPresented: $showingDocumentPicker) {
+                DocumentPicker { url in
+                    if let url {
+                        Task {
+                            await viewModel.handleFileSelection(url: url)
+                            await guestsViewModel.refresh()
+                        }
+                    }
+                }
+            }
+            .onAppear {
+                Task {
+                    if let store = guestsViewModel.store {
+                        viewModel.configure(with: store)
+                    }
+                }
+            }
+        }
+    }
+}
+
+struct DocumentPicker: UIViewControllerRepresentable {
+    var completion: (URL?) -> Void
+
+    func makeUIViewController(context: Context) -> UIDocumentPickerViewController {
+        let types: [UTType] = [UTType(filenameExtension: "xlsx")!, .commaSeparatedText]
+        let controller = UIDocumentPickerViewController(forOpeningContentTypes: types, asCopy: true)
+        controller.delegate = context.coordinator
+        return controller
+    }
+
+    func updateUIViewController(_ uiViewController: UIDocumentPickerViewController, context: Context) {}
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(completion: completion)
+    }
+
+    final class Coordinator: NSObject, UIDocumentPickerDelegate {
+        let completion: (URL?) -> Void
+
+        init(completion: @escaping (URL?) -> Void) {
+            self.completion = completion
+        }
+
+        func documentPicker(_ controller: UIDocumentPickerViewController, didPickDocumentsAt urls: [URL]) {
+            completion(urls.first)
+        }
+
+        func documentPickerWasCancelled(_ controller: UIDocumentPickerViewController) {
+            completion(nil)
+        }
+    }
+}

--- a/Sources/AppModule/Views/ScanView.swift
+++ b/Sources/AppModule/Views/ScanView.swift
@@ -1,0 +1,157 @@
+import SwiftUI
+import AVFoundation
+
+struct ScanView: View {
+    @EnvironmentObject private var viewModel: ScanViewModel
+
+    var body: some View {
+        ZStack(alignment: .top) {
+            CameraPreview(layer: viewModel.makePreviewLayer())
+                .ignoresSafeArea()
+            VStack {
+                header
+                Spacer()
+                statusBanner
+                historyList
+            }
+            .padding(16)
+        }
+        .onAppear {
+            AVCaptureDevice.requestAccess(for: .video) { _ in }
+        }
+    }
+
+    private var header: some View {
+        HStack {
+            Text("Scan Tickets")
+                .font(.largeTitle)
+                .bold()
+                .foregroundColor(.white)
+            Spacer()
+            Button(action: { viewModel.toggleTorch() }) {
+                Image(systemName: viewModel.torchEnabled ? "bolt.fill" : "bolt.slash.fill")
+                    .foregroundColor(.white)
+                    .padding(8)
+                    .background(Color.black.opacity(0.4))
+                    .clipShape(Circle())
+            }
+        }
+    }
+
+    private var statusBanner: some View {
+        Group {
+            switch viewModel.state {
+            case .idle:
+                EmptyView()
+            case .success(let name, let time, let code):
+                ScanResultCard(icon: "checkmark.seal", color: Color(hex: "2E7D32"), title: "Admitted", subtitle: name, detail: DateFormatter.timeFormatter.string(from: time) + " • #" + code)
+            case .duplicate(let name, let time):
+                ScanResultCard(icon: "exclamationmark.triangle", color: Color(hex: "F9A825"), title: "Already checked in", subtitle: name, detail: DateFormatter.timeFormatter.string(from: time))
+            case .invalid:
+                ScanResultCard(icon: "xmark.octagon", color: Color(hex: "C62828"), title: "Invalid or tampered ticket", subtitle: "", detail: nil)
+            }
+        }
+        .frame(maxWidth: .infinity)
+    }
+
+    private var historyList: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Recent Scans")
+                .font(.headline)
+                .foregroundColor(.white)
+                .frame(maxWidth: .infinity, alignment: .leading)
+            ForEach(viewModel.recentScans) { record in
+                ScanHistoryRow(record: record)
+            }
+        }
+        .padding()
+        .background(Color.black.opacity(0.4))
+        .clipShape(RoundedRectangle(cornerRadius: 16))
+    }
+}
+
+struct CameraPreview: UIViewRepresentable {
+    let layer: AVCaptureVideoPreviewLayer?
+
+    func makeUIView(context: Context) -> UIView {
+        let view = UIView()
+        if let layer = layer {
+            layer.frame = UIScreen.main.bounds
+            view.layer.addSublayer(layer)
+        }
+        return view
+    }
+
+    func updateUIView(_ uiView: UIView, context: Context) {
+        layer?.frame = uiView.bounds
+    }
+}
+
+struct ScanResultCard: View {
+    let icon: String
+    let color: Color
+    let title: String
+    let subtitle: String
+    let detail: String?
+
+    var body: some View {
+        HStack(alignment: .center, spacing: 12) {
+            Image(systemName: icon)
+                .foregroundColor(.white)
+                .padding(12)
+                .background(color)
+                .clipShape(Circle())
+            VStack(alignment: .leading, spacing: 4) {
+                Text(title)
+                    .font(.headline)
+                if !subtitle.isEmpty {
+                    Text(subtitle)
+                        .font(.subheadline)
+                }
+                if let detail {
+                    Text(detail)
+                        .font(.footnote)
+                        .foregroundColor(.secondary)
+                }
+            }
+            Spacer()
+        }
+        .padding()
+        .background(Color(.systemBackground).opacity(0.9))
+        .clipShape(RoundedRectangle(cornerRadius: 16))
+    }
+}
+
+struct ScanHistoryRow: View {
+    let record: ScanRecord
+
+    var body: some View {
+        HStack {
+            Circle()
+                .fill(color(for: record.status))
+                .frame(width: 12, height: 12)
+            Text(record.name ?? "Unknown")
+                .foregroundColor(.white)
+            Spacer()
+            Text(DateFormatter.timeFormatter.string(from: record.timestamp))
+                .font(.caption)
+                .foregroundColor(.white.opacity(0.7))
+        }
+    }
+
+    private func color(for status: ScanRecord.Status) -> Color {
+        switch status {
+        case .success: return Color(hex: "2E7D32")
+        case .duplicate: return Color(hex: "F9A825")
+        case .invalid: return Color(hex: "C62828")
+        }
+    }
+}
+
+private extension DateFormatter {
+    static let timeFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.timeStyle = .medium
+        return formatter
+    }()
+}

--- a/Sources/AppModule/Views/SettingsView.swift
+++ b/Sources/AppModule/Views/SettingsView.swift
@@ -1,0 +1,116 @@
+import SwiftUI
+import UIKit
+
+struct SettingsView: View {
+    @EnvironmentObject private var guestsViewModel: GuestsViewModel
+    @State private var eventName: String = ""
+    @State private var showSecret = false
+    @State private var secretText: String = ""
+    @State private var showClearConfirmation = false
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section(header: Text("Event")) {
+                    TextField("Event Name", text: $eventName)
+                    Button("Regenerate Secret", role: .destructive) {
+                        Task { await regenerateSecret() }
+                    }
+                    Button(showSecret ? "Hide Secret" : "Show Secret") {
+                        showSecret.toggle()
+                    }
+                    if showSecret {
+                        Text(secretText)
+                            .font(.footnote)
+                            .textSelection(.enabled)
+                    }
+                }
+
+                Section(header: Text("Data Management")) {
+                    Button("Export Guests (CSV)") {
+                        Task { await exportGuests() }
+                    }
+                    Button("Clear All Data", role: .destructive) {
+                        showClearConfirmation = true
+                    }
+                }
+
+                Section(header: Text("About")) {
+                    Text("Version 1.0")
+                    Text("All data is stored locally and works offline.")
+                        .font(.footnote)
+                }
+            }
+            .navigationTitle("Settings")
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Done") { dismiss() }
+                }
+            }
+            .task {
+                await loadValues()
+            }
+            .onChange(of: eventName) { newValue in
+                Task {
+                    await updateEventName(newValue)
+                }
+            }
+            .alert("Clear all data?", isPresented: $showClearConfirmation) {
+                Button("Cancel", role: .cancel) {}
+                Button("Clear", role: .destructive) {
+                    Task { await clearData() }
+                }
+            }
+        }
+    }
+
+    @Environment(\.dismiss) private var dismiss
+
+    private func loadValues() async {
+        guard let store = guestsViewModel.store else { return }
+        let config = await store.eventConfig
+        await MainActor.run {
+            eventName = config.eventName
+            secretText = config.hmacSecret.base64EncodedString()
+        }
+    }
+
+    private func regenerateSecret() async {
+        guard let store = guestsViewModel.store else { return }
+        try? await store.updateEventConfig { config in
+            config.hmacSecret = HMACSecretGenerator.generate()
+            config.keyVersion += 1
+        }
+        await loadValues()
+    }
+
+    private func clearData() async {
+        guard let store = guestsViewModel.store else { return }
+        try? await store.replaceAll(with: [])
+        await guestsViewModel.refresh()
+    }
+
+    private func updateEventName(_ name: String) async {
+        guard let store = guestsViewModel.store else { return }
+        try? await store.updateEventConfig { config in
+            config.eventName = name
+        }
+    }
+
+    private func exportGuests() async {
+        guard let store = guestsViewModel.store else { return }
+        let guests = await store.refresh()
+        let csv = guests.map { $0.fullName }.joined(separator: "\n")
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("Guests.csv")
+        try? csv.write(to: url, atomically: true, encoding: .utf8)
+        await presentShareSheet(with: url)
+    }
+
+    @MainActor
+    private func presentShareSheet(with url: URL) async {
+        let controller = UIActivityViewController(activityItems: [url], applicationActivities: nil)
+        guard let scene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+              let root = scene.windows.first?.rootViewController else { return }
+        root.present(controller, animated: true)
+    }
+}

--- a/Sources/AppModule/Views/TicketPreviewView.swift
+++ b/Sources/AppModule/Views/TicketPreviewView.swift
@@ -1,0 +1,85 @@
+import SwiftUI
+import UIKit
+
+struct TicketPreviewView: View {
+    let guest: Guest
+    let ticket: QRTicket
+    let image: UIImage
+    let onShare: (URL) -> Void
+    @EnvironmentObject private var guestsViewModel: GuestsViewModel
+    @Environment(\.dismiss) private var dismiss
+    @State private var isSharing = false
+    @State private var shareURL: URL?
+
+    var body: some View {
+        NavigationStack {
+            VStack(spacing: 24) {
+                Text(guestsViewModel.eventName.isEmpty ? "Event" : guestsViewModel.eventName)
+                    .font(.title)
+                    .bold()
+                Text(guest.fullName)
+                    .font(.largeTitle)
+                    .bold()
+                Text("Ticket #\(ticket.code)")
+                    .font(.headline)
+                    .foregroundColor(.secondary)
+                Image(uiImage: image)
+                    .interpolation(.none)
+                    .resizable()
+                    .scaledToFit()
+                    .frame(width: 240, height: 240)
+                    .background(Color(.systemBackground))
+                    .cornerRadius(16)
+                Text("Show this QR at the entrance")
+                    .font(.footnote)
+                    .foregroundColor(.secondary)
+                Spacer()
+                HStack(spacing: 12) {
+                    Button(action: share) {
+                        Label("Share", systemImage: "square.and.arrow.up")
+                            .frame(maxWidth: .infinity)
+                    }
+                    .buttonStyle(.borderedProminent)
+                    Button(action: savePDF) {
+                        Label("Save", systemImage: "tray.and.arrow.down")
+                            .frame(maxWidth: .infinity)
+                    }
+                    .buttonStyle(.bordered)
+                }
+            }
+            .padding(24)
+            .navigationTitle("Ticket")
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Done") { dismiss() }
+                }
+            }
+            .sheet(isPresented: $isSharing, onDismiss: { shareURL = nil }) {
+                if let shareURL {
+                    ActivityView(activityItems: [shareURL])
+                }
+            }
+        }
+    }
+
+    private func share() {
+        guard let url = try? PDFTicketRenderer().renderTicket(eventName: guestsViewModel.eventName, guest: guest, ticket: ticket, image: image) else { return }
+        shareURL = url
+        isSharing = true
+    }
+
+    private func savePDF() {
+        guard let url = try? PDFTicketRenderer().renderTicket(eventName: guestsViewModel.eventName, guest: guest, ticket: ticket, image: image) else { return }
+        onShare(url)
+    }
+}
+
+struct ActivityView: UIViewControllerRepresentable {
+    let activityItems: [Any]
+
+    func makeUIViewController(context: Context) -> UIActivityViewController {
+        UIActivityViewController(activityItems: activityItems, applicationActivities: nil)
+    }
+
+    func updateUIViewController(_ uiViewController: UIActivityViewController, context: Context) {}
+}


### PR DESCRIPTION
## Summary
- add a SwiftUI-based iOS 16 application package that manages guests locally with search, sorting, filtering, undo delete, and QR ticket actions
- implement Excel/CSV import with normalization and optional bulk ticket issuance plus offline QR verification, ticket preview, PDF generation, and Share Sheet support
- include supporting services for HMAC ticket signatures, PDF rendering, camera scanning, and configurable event settings

## Testing
- not run (iOS project requires Xcode simulator/device)


------
https://chatgpt.com/codex/tasks/task_e_68d88623b370832fa320015d9d1f5cd2